### PR TITLE
Fix problem with extra characters in subtitle

### DIFF
--- a/LyndaDecryptor/CaptionToSrt.cs
+++ b/LyndaDecryptor/CaptionToSrt.cs
@@ -45,77 +45,178 @@ namespace LyndaDecryptor
             }
         }
 
-        public string preparesrt()
+        public string bytesToString(byte[] bytes, int from, int length)
         {
-            //read all file in memory
-            string content = File.ReadAllText(filePath);
+            return System.Text.Encoding.UTF8.GetString(bytes, from, length);
+        }
 
-            //crude replacement of characters that are not plain text. File has NUL, SOX, ACK and other non printing ASCII / binary chars
-            //Observed a pattern in file, rows in caption are ordered/marked by 
-            // a structure of characters of the form [ACK]<0-9A-Z>[NUL] remove these first
-            // a structure of characters of the form [ACK]<0-9A-Z>[SOH] remove these first
-            string output = Regex.Replace(content, @"\u0006[\u0020-\u007F][\u0000\u0001\u0002]", "");
+        public byte[] stringToBytes(string text)
+        {
+            return System.Text.Encoding.UTF8.GetBytes(text);
+        }
 
-            //there are some chars right after the timestamp ] and before [NUL] or [SOH] or [ETB] chars, drop them 
-            output = Regex.Replace(output, @"\][^\]\u0000-\u001F]+[\u0000-\u001F]", "]");
+        public int searchByteArray(byte[] inputByteArray, byte[] searchBytes, int startPosition)
+        {
+            // This function is similar to the String.IndexOf() function, but for byte arrays.
+            // The input array is searched for the occurrence of the search term, also represented as a byte array, using a Boyer-Moore search algorithm.
 
-            //delete all non-UTF8 ASCII printable chars by this regexp
-            output = Regex.Replace(output, @"[^\u0020-\u007F \u000D\n\r]+", "");
-
-            //now we might be left with a newline or useless white space after the timestamp and before the text, delete that too
-            output = Regex.Replace(output, @"\][ \n\r\t]", "");
-
-            //remove all info at start of file used by Lynda desktop app to link subtitle to video
-            //presume first timestamp starts with '[00:00...' so this is where the actual subtitle text starts
-            if (output.IndexOf("[0") > 0)
+            // Build jumptable
+            Dictionary<Byte, int> jumptable = new Dictionary<Byte, int>();
+            int searchBytesMaxIndex = searchBytes.Length - 1;
+            Byte currentSearchByte;
+            for (int searchBytesIndex = searchBytesMaxIndex; searchBytesIndex >= 0; searchBytesIndex--)
             {
-                output = output.Substring(output.IndexOf("[0"));
+                currentSearchByte = searchBytes[searchBytesIndex];
+                if (! jumptable.ContainsKey(currentSearchByte))
+                {
+                    jumptable.Add(currentSearchByte, searchBytesMaxIndex - searchBytesIndex);
+                }
             }
-            return output;
+            // Remove last character in the search term from the jumptable.
+            // It was useful for preventing other occurrences of this character from ending up in the jumptable, but it's not used for searching.
+            // Technically it wouldn't break anything by being there but let's remove it for the sake of clarity.
+            jumptable.Remove(searchBytes[searchBytesMaxIndex]);
+
+            // Perform the search
+            int inputArrayIndex = startPosition + searchBytesMaxIndex;
+            Byte currentInputByte;
+            bool matchFound;
+            while (inputArrayIndex < inputByteArray.Length)
+            {
+                matchFound = true; // Match not actually found yet, but if this is still true after the full comparison completes there's an actual match.
+                for (int searchBytesIndex = searchBytesMaxIndex; searchBytesIndex >= 0; searchBytesIndex--)
+                {
+                    currentInputByte = inputByteArray[inputArrayIndex - (searchBytesMaxIndex - searchBytesIndex)];
+                    currentSearchByte = searchBytes[searchBytesIndex];
+                    if (currentInputByte == currentSearchByte)
+                    {
+                        // This character matches, check next character.
+                        continue;
+                    }
+                    else
+                    {
+                        if (jumptable.ContainsKey(currentInputByte))
+                        {
+                            // Another character in the search term matches this input character. Jump forward by the corresponding amount.
+                            inputArrayIndex = inputArrayIndex + jumptable[currentInputByte];
+                        }
+                        else
+                        {
+                            // This character doesn't have any match, jump past it.
+                            inputArrayIndex = inputArrayIndex + searchBytesIndex + 1;
+                        }
+                        // No match for the search term at this position, stop checking further characters of the search term.
+                        matchFound = false;
+                        break;
+                    }
+                }
+                if (matchFound)
+                {
+                    // Match was found; return its position and exit function.
+                    return inputArrayIndex - searchBytesMaxIndex;
+                }
+            }
+            // No match was found in the entire input (from the start position). Return -1.
+            return -1;
+        }
+
+        public byte[][] splitByteArrayByDelimiter(byte[]  inputByteArray, byte[] delimiter)
+        {
+            // This function is similar to the String.Split() function, but for byte arrays.
+            // The array is split into multiple parts at the places where the delimiter occurs.
+
+            List<byte[]> choppedArray = new List<byte[]>();
+            int chopPoint = 0;
+            int chopLength;
+            byte[] newChop;
+            int delimiterFoundPosition;
+
+            // Look for the delimiter in the input array until all occurrences have been found.
+            do
+            {
+                // Search for delimiter in input array.
+                delimiterFoundPosition = searchByteArray(inputByteArray, delimiter, chopPoint);
+                if (delimiterFoundPosition >= 0)
+                {
+                    // Cut everything between this occurrence of the delimiter and the last.
+                    chopLength = delimiterFoundPosition - chopPoint;
+                }
+                else
+                {
+                    // Delimiter not found, append remaining part of the input to the final result.
+                    chopLength = inputByteArray.Length - chopPoint;
+                }
+                // Cut the text adjacent to the delimiters and add it to the output array.
+                newChop = new byte[chopLength];
+                Array.Copy(inputByteArray, chopPoint, newChop, 0, chopLength);
+                choppedArray.Add(newChop);
+                chopPoint = delimiterFoundPosition + delimiter.Length + 1;
+            } while (delimiterFoundPosition >= 0);
+            return choppedArray.ToArray();
         }
 
         public bool convertToSrt()
         {
-            string output = preparesrt();
+            ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+            // The .caption files consist of subtitle data with extraneous, non-printable data interposed.                                                                //
+            // The subtitle data is positioned at predictable locations in the file. This function operates based on that principle.                                      //
+            // The code below mostly deals with the subtitles in byte-form. While performing these operations on strings would be more simple and concise,                //
+            // it can interfere with the evenly-spaced layout of the data, sometimes producing extra or missing characters. Handling the data in byte-form prevents that. //
+            ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-            //split full formatted text in subtitle sections at start of timestamp
-            string[] phrases = Regex.Split(output, @"(?=\[[0-9])");
+            // Read content of source subtitle file as bytes
+            byte[] subtitleFile = File.ReadAllBytes(filePath);
 
-            string start;
+            // Split by double newlines (CRLFCRLF).
+            byte[][] rawSubtitles = splitByteArrayByDelimiter(subtitleFile, stringToBytes("\r\n\r\n"));
+
+            byte[] rawSubtitle;
+            string timestamp;
             string text;
-            string[] subline;
             ArrayList timestamps = new ArrayList();
             ArrayList captions = new ArrayList();
-            for (int i = 0; i < phrases.Length; i++)
+            string timeStartCharacter;
+            string timeEndCharacter;
+            int returnPosition;
+
+            // Following are the fixed beginning and ending positions for the timestamp and subtitle text.
+            // If subtitles are produced that look like they have erroneous extra or missing characters, try tweaking these numbers.
+            // Looking at the source subtitle file with a hex editor may help determine the correct positions.
+            int timeStartPosition = 15;  // Timestamp opening bracket always occurs at this position.
+            int timeEndPosition = 27;    // Timestamp closing bracket always occurs at this position.
+            int textStartPosition = 42;  // Subtitle text always starts at this position and continues until the end of the raw subtitle.
+
+            // Extract timestamp and text from subtitle.
+            for (int subtitleIndex = 0; subtitleIndex < rawSubtitles.Length; subtitleIndex++)
             {
                 try
                 {
-                    //get timestamp and text separately
-                    subline = Regex.Split(phrases[i], @"(?<=\[[0-9:,.]+\])");
-                    if (subline.Length == 2)
+                    rawSubtitle = rawSubtitles[subtitleIndex];
+                    if (rawSubtitle.Length < textStartPosition)
                     {
+                        // Skip this line if it's not even long enough to have subtitle text.
+                        continue;
+                    }
+                    timeStartCharacter = bytesToString(rawSubtitle, timeStartPosition, 1);
+                    timeEndCharacter = bytesToString(rawSubtitle, timeEndPosition, 1);
+                    if (timeStartCharacter == "[" && timeEndCharacter == "]")
+                    {
+                        // Extract the timestamp excluding the brackets.
+                        timestamp = bytesToString(rawSubtitle, timeStartPosition + 1, timeEndPosition - (timeStartPosition + 1));
                         //separator for miliseconds is ',' in srt, '.' in .caption switch it
-                        start = Regex.Replace(subline[0], "\\.", ",");
-                        start = start.Substring(1, start.Length - 2);
-                        text = subline[1];
-                        //there may be a number or sign before the actual text, drop it.
-                        //ATTENTION, if there is a subtitle phrase starting eth numbers or symbols this line will delete information from it
-                        text = Regex.Replace(text, @"^[\u0020-\u0040\-\u005B-\u0060]{1,2}[\r\n\t]?", "");
-                        //and delete any useless newlines at the end.
-                        text = Regex.Replace(text, @"[\r\n\t]+[\u0020-\u0040\-]?$", "");
-                        text = Regex.Replace(text, @"^[a-zA-Z0-9.]{0,2}[\r\n\t]+", "");
-                        timestamps.Add(start);
-                        captions.Add(text);
-                    }
-                    else if (subline.Length == 1 && i == phrases.Length - 1)
-                    {
-                        //add last timestamp to subtitle
-                        start = Regex.Replace(subline[0], "\\.", ",");
-                        start = start.Substring(1, start.Length - 2);
-                        timestamps.Add(start);
+                        timestamp = Regex.Replace(timestamp, "\\.", ",");
+                        timestamps.Add(timestamp);
 
+                        // Only add subtitle text if there is no return before before its start position (meaning there is no text following the timestamp).
+                        returnPosition = searchByteArray(rawSubtitle, stringToBytes("\r\n"), timeEndPosition + 1);
+                        if (returnPosition > textStartPosition || returnPosition == -1)
+                        {
+                            // Add subtitle text from its start position until the end of the raw subtitle.
+                            text = bytesToString(rawSubtitle, textStartPosition, rawSubtitle.Length - textStartPosition);
+                            captions.Add(text);
+                        }
                     }
-                        this.buildSrt(timestamps, captions, this.outFile);
+                    this.buildSrt(timestamps, captions, this.outFile);
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
I made some modifications to the way subtitles are extracted. Looking closely at the .caption files, I discovered the timestamps and subtitles appear at predictable positions. This allows them to be separated from the binary data without needing to filter any characters. I tested this method on 16 courses, and so far I've only had good results.